### PR TITLE
Support COPC point formats 6, 7, and 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A fast, memory-efficient converter that turns LAS/LAZ point cloud files into [CO
 
 ## Features
 
-- Produces spec-compliant COPC 1.0 files (LAS 1.4, point format 7)
+- Produces spec-compliant COPC 1.0 files (LAS 1.4, point format 6, 7, or 8 — automatically chosen from input)
 - Merges multiple input files into a single COPC output
 - Out-of-core processing with a configurable memory budget — handles datasets larger than RAM
 - Parallel reading, octree construction, and LAZ compression via rayon
@@ -67,10 +67,11 @@ copc_converter ./my_survey/ -o survey.copc.laz --memory-limit 8G
 
 ## How it works
 
-1. **Scan** — reads headers from all input files in parallel to determine bounds, CRS, and point count.
-2. **Distribute** — reads every point, assigns it to an octree leaf voxel, and writes it to a temporary file on disk.
-3. **Build** — constructs the octree bottom-up, thinning points at each level to produce multi-resolution LODs.
-4. **Write** — encodes and compresses nodes in parallel into a single COPC file with a hierarchy EVLR for spatial indexing.
+1. **Scan** — reads headers from all input files in parallel to determine bounds, CRS, point format, and point count.
+2. **Validate** — checks that all input files share the same CRS and point format, and selects the appropriate COPC output format (6, 7, or 8).
+3. **Distribute** — reads every point, assigns it to an octree leaf voxel, and writes it to a temporary file on disk.
+4. **Build** — constructs the octree bottom-up, thinning points at each level to produce multi-resolution LODs.
+5. **Write** — encodes and compresses nodes in parallel into a single COPC file with a hierarchy EVLR for spatial indexing.
 
 ## License
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod copc_types;
 mod octree;
+mod validate;
 mod writer;
 
 use anyhow::{Context, Result};
@@ -102,7 +103,12 @@ fn main() -> Result<()> {
         "=== Pass 1: scanning {} input file(s) ===",
         input_files.len()
     );
-    let builder = octree::OctreeBuilder::scan(&input_files, &config)?;
+    let scan_results = octree::OctreeBuilder::scan(&input_files)?;
+
+    info!("=== Validating inputs ===");
+    let validated = validate::validate(&input_files, &scan_results)?;
+
+    let builder = octree::OctreeBuilder::from_scan(&scan_results, &validated, &config)?;
 
     info!("=== Pass 2: distributing points to leaf voxels ===");
     builder.distribute(&input_files, &config)?;

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -310,6 +310,29 @@ pub fn point_to_key(
 // OctreeBuilder
 // ---------------------------------------------------------------------------
 
+/// Map an input LAS point format ID (0–10) to a COPC-compatible output format (6, 7, or 8).
+pub fn input_to_copc_format(id: u8) -> u8 {
+    match id {
+        2 | 3 | 5 | 7 => 7,
+        8 | 10 => 8,
+        _ => 6, // 0, 1, 4, 6, 9
+    }
+}
+
+/// Per-file results from the scan phase, used by validation.
+pub struct ScanResult {
+    pub bounds: Bounds,
+    pub point_count: u64,
+    pub scale_x: f64,
+    pub scale_y: f64,
+    pub scale_z: f64,
+    pub offset_x: f64,
+    pub offset_y: f64,
+    pub offset_z: f64,
+    pub wkt_crs: Option<Vec<u8>>,
+    pub point_format_id: u8,
+}
+
 pub struct OctreeBuilder {
     pub bounds: Bounds,
     pub total_points: u64,
@@ -329,15 +352,16 @@ pub struct OctreeBuilder {
     pub tmp_dir: PathBuf,
     /// WKT CRS payload from the first input file (if present).
     pub wkt_crs: Option<Vec<u8>>,
+    /// COPC output point format (6, 7, or 8), derived from input files.
+    pub point_format: u8,
 }
 
 impl OctreeBuilder {
     /// Pass 1: scan all files in parallel to get bounds and total point count.
-    pub fn scan(input_files: &[PathBuf], config: &PipelineConfig) -> Result<Self> {
-        type Transforms = (f64, f64, f64, f64, f64, f64);
-        let results: Vec<(Bounds, u64, Transforms, Option<Vec<u8>>)> = input_files
+    pub fn scan(input_files: &[PathBuf]) -> Result<Vec<ScanResult>> {
+        input_files
             .par_iter()
-            .map(|path| -> Result<_> {
+            .map(|path| -> Result<ScanResult> {
                 info!("Scanning {:?}", path);
                 let reader = las::Reader::from_path(path)
                     .with_context(|| format!("Cannot open {:?}", path))?;
@@ -346,42 +370,42 @@ impl OctreeBuilder {
                 let mut bounds = Bounds::empty();
                 bounds.expand_with(b.min.x, b.min.y, b.min.z);
                 bounds.expand_with(b.max.x, b.max.y, b.max.z);
-                let point_count = hdr.number_of_points();
                 let t = hdr.transforms();
-                let transforms = (
-                    t.x.scale, t.y.scale, t.z.scale, t.x.offset, t.y.offset, t.z.offset,
-                );
-                let wkt = hdr
-                    .all_vlrs()
-                    .find(|v| v.is_wkt_crs())
-                    .map(|v| v.data.clone());
-                Ok((bounds, point_count, transforms, wkt))
+                Ok(ScanResult {
+                    bounds,
+                    point_count: hdr.number_of_points(),
+                    scale_x: t.x.scale,
+                    scale_y: t.y.scale,
+                    scale_z: t.z.scale,
+                    offset_x: t.x.offset,
+                    offset_y: t.y.offset,
+                    offset_z: t.z.offset,
+                    wkt_crs: hdr
+                        .all_vlrs()
+                        .find(|v| v.is_wkt_crs())
+                        .map(|v| v.data.clone()),
+                    point_format_id: hdr.point_format().to_u8().unwrap_or(0),
+                })
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect()
+    }
 
+    /// Build an OctreeBuilder from scan results and validated inputs.
+    pub fn from_scan(
+        scan_results: &[ScanResult],
+        validated: &crate::validate::ValidatedInputs,
+        config: &PipelineConfig,
+    ) -> Result<Self> {
         let mut bounds = Bounds::empty();
         let mut total_points = 0u64;
-        for (b, count, _, _) in &results {
-            bounds.merge(b);
-            total_points += count;
+        for r in scan_results {
+            bounds.merge(&r.bounds);
+            total_points += r.point_count;
         }
 
-        let (scale_x, scale_y, scale_z, offset_x, offset_y, offset_z) = results
-            .first()
-            .map(|(_, _, t, _)| *t)
-            .unwrap_or((0.001, 0.001, 0.001, 0.0, 0.0, 0.0));
-
-        // Extract WKT CRS from the first file and verify all files match.
-        let wkt_crs = results[0].3.clone();
-        for (i, (_, _, _, wkt)) in results.iter().enumerate().skip(1) {
-            if *wkt != wkt_crs {
-                anyhow::bail!(
-                    "CRS mismatch: file {:?} has a different WKT CRS than {:?}",
-                    input_files[i],
-                    input_files[0],
-                );
-            }
-        }
+        let first = &scan_results[0];
+        let (scale_x, scale_y, scale_z) = (first.scale_x, first.scale_y, first.scale_z);
+        let (offset_x, offset_y, offset_z) = (first.offset_x, first.offset_y, first.offset_z);
 
         let (cx, cy, cz, halfsize) = bounds.to_cube();
 
@@ -418,7 +442,8 @@ impl OctreeBuilder {
             offset_y,
             offset_z,
             tmp_dir,
-            wkt_crs,
+            wkt_crs: validated.wkt_crs.clone(),
+            point_format: validated.point_format,
         })
     }
 
@@ -448,7 +473,7 @@ impl OctreeBuilder {
             red: p.color.as_ref().map(|c| c.red).unwrap_or(0),
             green: p.color.as_ref().map(|c| c.green).unwrap_or(0),
             blue: p.color.as_ref().map(|c| c.blue).unwrap_or(0),
-            nir: 0,
+            nir: p.nir.unwrap_or(0),
         }
     }
 
@@ -1166,5 +1191,25 @@ mod tests {
             single_buf, bulk_buf,
             "bulk write must produce identical bytes to single write"
         );
+    }
+
+    #[test]
+    fn input_to_copc_format_mapping() {
+        // No color, no NIR → format 6
+        assert_eq!(input_to_copc_format(0), 6);
+        assert_eq!(input_to_copc_format(1), 6);
+        assert_eq!(input_to_copc_format(4), 6);
+        assert_eq!(input_to_copc_format(6), 6);
+        assert_eq!(input_to_copc_format(9), 6);
+
+        // Has color, no NIR → format 7
+        assert_eq!(input_to_copc_format(2), 7);
+        assert_eq!(input_to_copc_format(3), 7);
+        assert_eq!(input_to_copc_format(5), 7);
+        assert_eq!(input_to_copc_format(7), 7);
+
+        // Has color + NIR → format 8
+        assert_eq!(input_to_copc_format(8), 8);
+        assert_eq!(input_to_copc_format(10), 8);
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,0 +1,104 @@
+/// Validate consistency of scanned input files before building the octree.
+use crate::octree::{ScanResult, input_to_copc_format};
+use anyhow::Result;
+use log::info;
+use std::path::PathBuf;
+
+/// Validated output: consistent properties across all input files.
+#[derive(Debug)]
+pub struct ValidatedInputs {
+    pub wkt_crs: Option<Vec<u8>>,
+    pub point_format: u8,
+}
+
+/// Check that all scanned files agree on CRS and point format,
+/// and derive the COPC output point format.
+pub fn validate(input_files: &[PathBuf], results: &[ScanResult]) -> Result<ValidatedInputs> {
+    let wkt_crs = results[0].wkt_crs.clone();
+    let first_format = results[0].point_format_id;
+
+    for (i, r) in results.iter().enumerate().skip(1) {
+        if r.wkt_crs != wkt_crs {
+            anyhow::bail!(
+                "CRS mismatch: {:?} has a different WKT CRS than {:?}",
+                input_files[i],
+                input_files[0],
+            );
+        }
+        if r.point_format_id != first_format {
+            anyhow::bail!(
+                "Point format mismatch: {:?} has format {} but {:?} has format {}",
+                input_files[i],
+                r.point_format_id,
+                input_files[0],
+                first_format,
+            );
+        }
+    }
+
+    let point_format = input_to_copc_format(first_format);
+    info!("Input point format: {first_format}, output COPC point format: {point_format}");
+
+    Ok(ValidatedInputs {
+        wkt_crs,
+        point_format,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::octree::{Bounds, ScanResult};
+
+    fn make_result(wkt: Option<Vec<u8>>, fmt: u8) -> ScanResult {
+        ScanResult {
+            bounds: Bounds::empty(),
+            point_count: 100,
+            scale_x: 0.001,
+            scale_y: 0.001,
+            scale_z: 0.001,
+            offset_x: 0.0,
+            offset_y: 0.0,
+            offset_z: 0.0,
+            wkt_crs: wkt,
+            point_format_id: fmt,
+        }
+    }
+
+    #[test]
+    fn validate_single_file() {
+        let files = vec![PathBuf::from("a.laz")];
+        let results = vec![make_result(None, 3)];
+        let v = validate(&files, &results).unwrap();
+        assert_eq!(v.point_format, 7);
+        assert!(v.wkt_crs.is_none());
+    }
+
+    #[test]
+    fn validate_matching_files() {
+        let files = vec![PathBuf::from("a.laz"), PathBuf::from("b.laz")];
+        let wkt = Some(b"WKT".to_vec());
+        let results = vec![make_result(wkt.clone(), 8), make_result(wkt, 8)];
+        let v = validate(&files, &results).unwrap();
+        assert_eq!(v.point_format, 8);
+    }
+
+    #[test]
+    fn validate_crs_mismatch() {
+        let files = vec![PathBuf::from("a.laz"), PathBuf::from("b.laz")];
+        let results = vec![
+            make_result(Some(b"WKT_A".to_vec()), 7),
+            make_result(Some(b"WKT_B".to_vec()), 7),
+        ];
+        let err = validate(&files, &results).unwrap_err();
+        assert!(err.to_string().contains("CRS mismatch"));
+    }
+
+    #[test]
+    fn validate_format_mismatch() {
+        let files = vec![PathBuf::from("a.laz"), PathBuf::from("b.laz")];
+        let results = vec![make_result(None, 3), make_result(None, 7)];
+        let err = validate(&files, &results).unwrap_err();
+        assert!(err.to_string().contains("Point format mismatch"));
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -4,8 +4,8 @@
 /// ------
 ///  [LAS 1.4 header]           375 bytes
 ///  [copc info VLR]            54 + 160 = 214 bytes
-///  [laszip VLR]               54 + 46  = 100 bytes   (user_id "laszip encoded", record_id 22204)
-///  --- offset_to_point_data = 689 ---
+///  [laszip VLR]               54 + variable (depends on point format)
+///  [WKT CRS VLR]              optional
 ///  [i64 chunk-table offset]   8 bytes  (points to chunk table after all data)
 ///  [compressed chunk 0]       variable
 ///  [compressed chunk 1]       variable
@@ -30,12 +30,19 @@ use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
-// LAS 1.4 format 7 raw byte size = 30 (base format 6) + 6 (RGB) = 36
+// Point record sizes: format 6 = 30, format 7 = 36, format 8 = 38
 // ---------------------------------------------------------------------------
-const POINT_RECORD_LENGTH: u16 = 36;
+fn point_record_length(fmt: u8) -> u16 {
+    match fmt {
+        6 => 30,
+        7 => 36,
+        8 => 38,
+        _ => 36,
+    }
+}
 
-/// Encode one point as LAS 1.4 format 7 raw bytes (36 bytes, little-endian).
-fn encode_point_fmt7(rp: &RawPoint, buf: &mut Vec<u8>) {
+/// Encode the format-6 base fields (30 bytes) shared by all COPC formats.
+fn encode_point_base(rp: &RawPoint, buf: &mut Vec<u8>) {
     buf.extend_from_slice(&rp.x.to_le_bytes());
     buf.extend_from_slice(&rp.y.to_le_bytes());
     buf.extend_from_slice(&rp.z.to_le_bytes());
@@ -48,10 +55,20 @@ fn encode_point_fmt7(rp: &RawPoint, buf: &mut Vec<u8>) {
     buf.extend_from_slice(&rp.scan_angle.to_le_bytes());
     buf.extend_from_slice(&rp.point_source_id.to_le_bytes());
     buf.extend_from_slice(&rp.gps_time.to_le_bytes());
-    buf.extend_from_slice(&rp.red.to_le_bytes());
-    buf.extend_from_slice(&rp.green.to_le_bytes());
-    buf.extend_from_slice(&rp.blue.to_le_bytes());
-    // Total = 4+4+4+2+1+1+1+1+2+2+8+2+2+2 = 36 bytes
+    // Total = 4+4+4+2+1+1+1+1+2+2+8 = 30 bytes
+}
+
+/// Encode one point according to the COPC output format (6, 7, or 8).
+fn encode_point(rp: &RawPoint, fmt: u8, buf: &mut Vec<u8>) {
+    encode_point_base(rp, buf);
+    if fmt >= 7 {
+        buf.extend_from_slice(&rp.red.to_le_bytes());
+        buf.extend_from_slice(&rp.green.to_le_bytes());
+        buf.extend_from_slice(&rp.blue.to_le_bytes());
+    }
+    if fmt >= 8 {
+        buf.extend_from_slice(&rp.nir.to_le_bytes());
+    }
 }
 
 /// Write a complete COPC file to `output_path`.
@@ -72,12 +89,15 @@ pub fn write_copc(
     let offset_y = builder.offset_y;
     let offset_z = builder.offset_z;
 
+    let point_format = builder.point_format;
+    let point_record_len = point_record_length(point_format);
+
     // -----------------------------------------------------------------------
-    // Build the LAZ VLR (variable-size chunks, format 7 items)
+    // Build the LAZ VLR (variable-size chunks)
     // -----------------------------------------------------------------------
     let laz_vlr = LazVlrBuilder::default()
-        .with_point_format(7, 0)
-        .context("LazVlrBuilder for format 7")?
+        .with_point_format(point_format, 0)
+        .context("LazVlrBuilder for format")?
         .with_variable_chunk_size()
         .build();
 
@@ -89,7 +109,7 @@ pub fn write_copc(
     // -----------------------------------------------------------------------
     let wkt_crs = &builder.wkt_crs;
     let copc_info_vlr_size: u32 = 54 + 160; // 214
-    let laz_vlr_size: u32 = 54 + laz_vlr_payload.len() as u32; // 100
+    let laz_vlr_size: u32 = 54 + laz_vlr_payload.len() as u32;
     let wkt_vlr_size: u32 = wkt_crs.as_ref().map(|d| 54 + d.len() as u32).unwrap_or(0);
     let num_vlrs: u32 = if wkt_crs.is_some() { 3 } else { 2 };
     let offset_to_point_data: u32 = 375 + copc_info_vlr_size + laz_vlr_size + wkt_vlr_size;
@@ -184,8 +204,8 @@ pub fn write_copc(
     w.write_u16::<LittleEndian>(375)?; // header size
     w.write_u32::<LittleEndian>(offset_to_point_data)?;
     w.write_u32::<LittleEndian>(num_vlrs)?; // number of VLRs
-    w.write_u8(128 | 7)?; // point format 135 = LAZ format 7
-    w.write_u16::<LittleEndian>(POINT_RECORD_LENGTH)?;
+    w.write_u8(128 | point_format)?; // LAZ compressed point format
+    w.write_u16::<LittleEndian>(point_record_len)?;
     w.write_u32::<LittleEndian>(0)?; // legacy point count
     for _ in 0..5 {
         w.write_u32::<LittleEndian>(0)?;
@@ -252,7 +272,7 @@ pub fn write_copc(
     // Parallel compression via ParLasZipCompressor
     // -----------------------------------------------------------------------
     let laz_vlr_for_compressor = LazVlrBuilder::default()
-        .with_point_format(7, 0)
+        .with_point_format(point_format, 0)
         .context("LazVlrBuilder (compressor)")?
         .with_variable_chunk_size()
         .build();
@@ -293,7 +313,7 @@ pub fn write_copc(
         while batch_end < data_keys.len() {
             let key = &data_keys[batch_end];
             let node_bytes =
-                (point_counts.get(key).copied().unwrap_or(0) as u64) * POINT_RECORD_LENGTH as u64;
+                (point_counts.get(key).copied().unwrap_or(0) as u64) * point_record_len as u64;
             // Always include at least one node per batch to avoid stalling.
             if batch_end > batch_start && batch_bytes + node_bytes > memory_budget {
                 break;
@@ -316,7 +336,7 @@ pub fn write_copc(
                 let mut local_returns = [0u64; 15];
                 let mut local_gps_min = f64::MAX;
                 let mut local_gps_max = f64::MIN;
-                let mut raw_bytes = Vec::with_capacity(POINT_RECORD_LENGTH as usize * pts.len());
+                let mut raw_bytes = Vec::with_capacity(point_record_len as usize * pts.len());
                 for rp in &pts {
                     let rn = rp.return_number as usize;
                     if (1..=15).contains(&rn) {
@@ -328,7 +348,7 @@ pub fn write_copc(
                     if rp.gps_time > local_gps_max {
                         local_gps_max = rp.gps_time;
                     }
-                    encode_point_fmt7(rp, &mut raw_bytes);
+                    encode_point(rp, point_format, &mut raw_bytes);
                 }
                 Ok((raw_bytes, local_returns, local_gps_min, local_gps_max))
             })
@@ -380,7 +400,7 @@ pub fn write_copc(
     // Read the chunk table back from the file to get per-chunk byte sizes
     // -----------------------------------------------------------------------
     let read_vlr = LazVlrBuilder::default()
-        .with_point_format(7, 0)
+        .with_point_format(point_format, 0)
         .context("LazVlrBuilder (read)")?
         .with_variable_chunk_size()
         .build();
@@ -476,4 +496,98 @@ pub fn write_copc(
 
     info!("COPC file written: {:?}", output_path);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_point() -> RawPoint {
+        RawPoint {
+            x: -123456,
+            y: 789012,
+            z: -1,
+            intensity: 65535,
+            return_number: 3,
+            number_of_returns: 5,
+            classification: 6,
+            scan_angle: -15000,
+            user_data: 42,
+            point_source_id: 1001,
+            gps_time: 123456789.987654,
+            red: 255,
+            green: 0,
+            blue: 65535,
+            nir: 32768,
+        }
+    }
+
+    #[test]
+    fn point_record_lengths() {
+        assert_eq!(point_record_length(6), 30);
+        assert_eq!(point_record_length(7), 36);
+        assert_eq!(point_record_length(8), 38);
+    }
+
+    #[test]
+    fn encode_point_format6_size() {
+        let p = sample_point();
+        let mut buf = Vec::new();
+        encode_point(&p, 6, &mut buf);
+        assert_eq!(buf.len(), 30);
+    }
+
+    #[test]
+    fn encode_point_format7_size() {
+        let p = sample_point();
+        let mut buf = Vec::new();
+        encode_point(&p, 7, &mut buf);
+        assert_eq!(buf.len(), 36);
+    }
+
+    #[test]
+    fn encode_point_format8_size() {
+        let p = sample_point();
+        let mut buf = Vec::new();
+        encode_point(&p, 8, &mut buf);
+        assert_eq!(buf.len(), 38);
+    }
+
+    #[test]
+    fn encode_point_format7_includes_rgb() {
+        let p = sample_point();
+        let mut buf = Vec::new();
+        encode_point(&p, 7, &mut buf);
+        // RGB starts at offset 30 (after base fields)
+        let red = u16::from_le_bytes([buf[30], buf[31]]);
+        let green = u16::from_le_bytes([buf[32], buf[33]]);
+        let blue = u16::from_le_bytes([buf[34], buf[35]]);
+        assert_eq!(red, p.red);
+        assert_eq!(green, p.green);
+        assert_eq!(blue, p.blue);
+    }
+
+    #[test]
+    fn encode_point_format8_includes_nir() {
+        let p = sample_point();
+        let mut buf = Vec::new();
+        encode_point(&p, 8, &mut buf);
+        // NIR starts at offset 36 (after RGB)
+        let nir = u16::from_le_bytes([buf[36], buf[37]]);
+        assert_eq!(nir, p.nir);
+    }
+
+    #[test]
+    fn encode_point_format6_matches_base_of_format7() {
+        let p = sample_point();
+        let mut buf6 = Vec::new();
+        let mut buf7 = Vec::new();
+        encode_point(&p, 6, &mut buf6);
+        encode_point(&p, 7, &mut buf7);
+        assert_eq!(
+            buf6[..],
+            buf7[..30],
+            "format 6 must match the first 30 bytes of format 7"
+        );
+    }
 }


### PR DESCRIPTION
- Automatically select COPC output point format (6, 7, or 8) based on input file format
- Validate that all input files share the same point format and CRS
- Extract validation into its own module and pipeline stage