### PR TITLE
Fix memory budget accounting in build and write stages

### DIFF
--- a/src/octree.rs
+++ b/src/octree.rs
@@ -797,7 +797,11 @@ impl OctreeBuilder {
 
         // Phase 2
         let result = if estimated_peak <= config.memory_budget {
-            info!("Building octree in-memory ({} MB, ~{} MB peak)", total_bytes / 1_048_576, estimated_peak / 1_048_576);
+            info!(
+                "Building octree in-memory ({} MB, ~{} MB peak)",
+                total_bytes / 1_048_576,
+                estimated_peak / 1_048_576
+            );
             self.bottom_up_in_memory(&leaf_keys, actual_max_depth)?
         } else {
             info!(
@@ -960,8 +964,8 @@ impl OctreeBuilder {
         // In-memory cost per point during grid_sample: the (usize, RawPoint) input
         // vec plus the output vecs (parent + per-child remaining) — roughly 2x the
         // input since points move from input to output.
-        const MEM_PER_POINT: u64 = (std::mem::size_of::<(usize, RawPoint)>()
-            + std::mem::size_of::<RawPoint>()) as u64;
+        const MEM_PER_POINT: u64 =
+            (std::mem::size_of::<(usize, RawPoint)>() + std::mem::size_of::<RawPoint>()) as u64;
 
         for d in (0..actual_max_depth).rev() {
             debug!("Building ancestor level {d}");

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -329,8 +329,7 @@ pub fn write_copc(
         let mut batch_end = batch_start;
         while batch_end < data_keys.len() {
             let key = &data_keys[batch_end];
-            let node_bytes =
-                (point_counts.get(key).copied().unwrap_or(0) as u64) * mem_per_point;
+            let node_bytes = (point_counts.get(key).copied().unwrap_or(0) as u64) * mem_per_point;
             // Always include at least one node per batch to avoid stalling.
             if batch_end > batch_start && batch_bytes + node_bytes > memory_budget {
                 break;


### PR DESCRIPTION
## Summary
- **Writer**: Batch budget now uses actual peak memory per point (`RawPoint::BYTE_SIZE + point_record_len` ≈ 78B) instead of just encoded bytes (~38B), preventing batches from using ~2x the configured memory limit
- **Build (disk path)**: Parents are now batched by estimated memory cost before `par_iter`, preventing unbounded parallel memory usage when many parents are processed at the same level
- **Build (in-memory path)**: Threshold tightened from `total_bytes` to `total_bytes * 2` to account for duplication during grid sampling

Fixes OOMKilled on K8s pods where `--memory-limit` was set close to the pod's actual memory limit.

## Test plan
- [ ] All 36 existing tests pass (unit, integration, doctest)
- [ ] Run on a large dataset with `--memory-limit` set to ~80% of available memory — should no longer OOM
- [ ] Verify output COPC files are identical (deterministic output test covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)