### PR TITLE
added support for geotiff crs also

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -37,15 +37,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -96,9 +96,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -120,9 +120,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -189,15 +189,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
@@ -244,6 +244,7 @@ dependencies = [
  "clap",
  "copc-streaming",
  "copc-temporal",
+ "crs-definitions",
  "futures",
  "indicatif",
  "las",
@@ -311,6 +312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crs-definitions"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5229c5b63bdc8e24d60e5c4b6115fbb4d11a8978661b4ecc57d6068ddb073983"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -564,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -615,9 +622,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -629,7 +636,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -637,15 +643,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -719,12 +724,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -732,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -745,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -759,15 +765,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -779,15 +785,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -827,12 +833,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -880,19 +886,21 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "las"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d35a98a0bf1e7d30cd61899741af22f853110021be78175926cc870a39dfd"
+checksum = "48c2594be0d2ec4f04c944f5cb5160625cd1a69451db14de73b990065f97fb84"
 dependencies = [
  "byteorder",
  "chrono",
@@ -928,9 +936,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -940,9 +948,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1043,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1055,9 +1063,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1087,9 +1095,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -1133,16 +1141,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1152,9 +1154,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1265,9 +1267,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1294,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1417,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "ring",
@@ -1441,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1502,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1722,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1747,9 +1749,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -1764,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1980,9 +1982,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2017,11 +2019,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2030,14 +2032,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2048,23 +2050,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2072,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2085,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2128,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2148,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2391,6 +2389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,15 +2475,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2488,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2520,18 +2524,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2547,9 +2551,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2558,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2569,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ copc-temporal = { version = "0.1.5", optional = true }
 futures = { version = "0.3", optional = true }
 reqwest = { version = "0.12", features = ["rustls-tls"], optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
+crs-definitions = "0.4.0"
 
 [dev-dependencies]
 byteorder = "1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,10 @@ pub enum Error {
         file_b: PathBuf,
     },
 
+    /// The parsed epsg code from the Crs data is out of range
+    #[error("The parsed Epsg Crs code is not in range")]
+    InvalidEpsgCrs(u16),
+
     /// Input files have mismatched point formats.
     #[error(
         "Point format mismatch: {file_a:?} has format {format_a} but {file_b:?} has format {format_b}"

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -1,3 +1,4 @@
+use crate::copc_types::VoxelKey;
 /// Out-of-core octree builder.
 ///
 /// Strategy
@@ -14,8 +15,7 @@
 /// 6. Produce the list of (VoxelKey, point_count) for the writer, which reads from disk.
 ///
 /// Memory usage is bounded by the configurable memory budget.
-use crate::PipelineConfig;
-use crate::copc_types::VoxelKey;
+use crate::{Error, PipelineConfig};
 use anyhow::{Context, Result};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use rayon::prelude::*;
@@ -728,6 +728,7 @@ pub fn input_to_copc_format(id: u8) -> u8 {
 }
 
 /// Per-file results from the scan phase, used by validation.
+#[derive(Debug, Clone)]
 pub struct ScanResult {
     pub bounds: Bounds,
     pub point_count: u64,
@@ -737,8 +738,145 @@ pub struct ScanResult {
     pub offset_x: f64,
     pub offset_y: f64,
     pub offset_z: f64,
-    pub wkt_crs: Option<Vec<u8>>,
+    pub crs: Option<Crs>,
     pub point_format_id: u8,
+}
+
+/// An enum describing the supported Crs options
+#[derive(Debug, Clone)]
+pub enum Crs {
+    Wkt(Vec<u8>),
+    GeoTiffEpsg(u16, Option<u16>),
+}
+
+impl Crs {
+    pub fn is_equal_to(&self, other: &Self) -> Result<bool> {
+        match (self, other) {
+            (Self::Wkt(l_bytes), Self::Wkt(r_bytes)) => {
+                // first check byte for byte eq
+                if l_bytes == r_bytes {
+                    return Ok(true);
+                }
+                // Try and grab epsg codes
+                let epsg_l = get_epsg_from_wkt_crs_bytes(l_bytes)?;
+                let epsg_r = get_epsg_from_wkt_crs_bytes(r_bytes)?;
+
+                Ok(epsg_l == epsg_r)
+            }
+            (Self::GeoTiffEpsg(l0, l1), Self::GeoTiffEpsg(r0, r1)) => Ok(l0 == r0 && l1 == r1),
+            (Self::GeoTiffEpsg(horizontal, vertical), Self::Wkt(bytes)) => {
+                let epsg_r = get_epsg_from_wkt_crs_bytes(bytes)?;
+                Ok(horizontal == &epsg_r.0 && vertical == &epsg_r.1)
+            }
+            (Self::Wkt(bytes), Self::GeoTiffEpsg(horizontal, vertical)) => {
+                let epsg_l = get_epsg_from_wkt_crs_bytes(bytes)?;
+                Ok(horizontal == &epsg_l.0 && vertical == &epsg_l.1)
+            }
+        }
+    }
+
+    pub fn is_equal_to_ignore_vertical_component(&self, other: &Self) -> Result<bool> {
+        match (self, other) {
+            (Self::Wkt(l_bytes), Self::Wkt(r_bytes)) => {
+                // first check byte for byte eq
+                if l_bytes == r_bytes {
+                    return Ok(true);
+                }
+                // Try and grab epsg codes
+                let epsg_l = get_epsg_from_wkt_crs_bytes(l_bytes)?;
+                let epsg_r = get_epsg_from_wkt_crs_bytes(r_bytes)?;
+                Ok(epsg_l.0 == epsg_r.0)
+            }
+            (Self::GeoTiffEpsg(l0, _l1), Self::GeoTiffEpsg(r0, _r1)) => Ok(l0 == r0),
+            (Self::GeoTiffEpsg(horizontal, _vertical), Self::Wkt(bytes)) => {
+                let epsg_r = get_epsg_from_wkt_crs_bytes(bytes)?;
+                Ok(horizontal == &epsg_r.0)
+            }
+            (Self::Wkt(bytes), Self::GeoTiffEpsg(horizontal, _vertical)) => {
+                let epsg_l = get_epsg_from_wkt_crs_bytes(bytes)?;
+                Ok(horizontal == &epsg_l.0)
+            }
+        }
+    }
+}
+
+/// Tries to parse EPSG code(s) from WKT-CRS bytes.
+///
+/// By parsing the EPSG codes at the end of the vertical and horizontal CRS sub-strings
+/// This is not true WKT parser and might provide a bad code if
+/// the WKT-CRS bytes does not look as expected
+pub fn get_epsg_from_wkt_crs_bytes(bytes: &[u8]) -> Result<(u16, Option<u16>)> {
+    pub const EPSG_RANGE: std::ops::Range<u16> = 1024..(i16::MAX as u16);
+    let wkt = String::from_utf8_lossy(bytes);
+
+    enum WktPieces<'a> {
+        One(&'a [u8]),
+        Two(&'a [u8], &'a [u8]),
+    }
+
+    impl WktPieces<'_> {
+        fn parse_codes(&self) -> (u16, Option<u16>) {
+            match self {
+                WktPieces::One(hor) => (Self::get_code(hor), None),
+                WktPieces::Two(hor, ver) => (Self::get_code(hor), Some(Self::get_code(ver))),
+            }
+        }
+
+        fn get_code(bytes: &[u8]) -> u16 {
+            // the EPSG code is located at the end of the substrings
+            // and so we iterate through the substrings backwards collecting
+            // digits and adding them to our EPSG code
+            let mut epsg_code = 0;
+            let mut code_has_started = false;
+            let mut power = 1;
+            // the 10 last bytes should be enough (with a small margin)
+            // as the code is 4 or 5 digits starting at the 2nd or 3rd byte from the back
+            for byte in bytes.trim_ascii_end().iter().rev().take(10) {
+                // if the byte is an ASCII encoded digit
+                if byte.is_ascii_digit() {
+                    // mark that the EPSG code has started
+                    // so that we can break when we no
+                    // longer find digits
+                    code_has_started = true;
+
+                    // translate from ASCII to digits
+                    // and multiply by powers of 10
+                    // sum it to build the EPSG
+                    // code digit by digit
+                    epsg_code += power * (byte - 48) as u16;
+                    power *= 10;
+                } else if code_has_started {
+                    // we no longer see digits
+                    // so the code must be over
+                    break;
+                }
+            }
+            epsg_code
+        }
+    }
+
+    // VERT_CS for WKT v1 and VERTCRS or VERTICALCRS for v2
+    let pieces = if let Some((horizontal, vertical)) = wkt.split_once("VERTCRS") {
+        WktPieces::Two(horizontal.as_bytes(), vertical.as_bytes())
+    } else if let Some((horizontal, vertical)) = wkt.split_once("VERTICALCRS") {
+        WktPieces::Two(horizontal.as_bytes(), vertical.as_bytes())
+    } else if let Some((horizontal, vertical)) = wkt.split_once("VERT_CS") {
+        WktPieces::Two(horizontal.as_bytes(), vertical.as_bytes())
+    } else {
+        WktPieces::One(wkt.as_bytes())
+    };
+
+    let mut codes = pieces.parse_codes();
+
+    if !EPSG_RANGE.contains(&codes.0) {
+        return Err(Error::InvalidEpsgCrs(codes.0).into());
+    }
+    if let Some(v_code) = codes.1
+        && !EPSG_RANGE.contains(&v_code)
+    {
+        codes.1 = None;
+    }
+    Ok(codes)
 }
 
 /// Builds a COPC octree from scanned input files.
@@ -790,28 +928,40 @@ impl OctreeBuilder {
                 debug!("Scanning {:?}", path);
                 let reader = las::Reader::from_path(path)
                     .with_context(|| format!("Cannot open {:?}", path))?;
-                let hdr = reader.header();
-                let b = hdr.bounds();
+                let header = reader.header();
+                let b = header.bounds();
                 let mut bounds = Bounds::empty();
                 bounds.expand_with(b.min.x, b.min.y, b.min.z);
                 bounds.expand_with(b.max.x, b.max.y, b.max.z);
-                let t = hdr.transforms();
+                let t = header.transforms();
                 let n = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                 config.report(crate::ProgressEvent::StageProgress { done: n });
+
+                let crs = if let Some(wkt) = header.get_wkt_crs_bytes() {
+                    Some(Crs::Wkt(wkt.to_owned()))
+                } else if let Ok(Some(geotiff)) = header.get_geotiff_crs() {
+                    let horizontal = match geotiff.get_gt_model_type_geo_key_value() {
+                        Some(1) => geotiff.get_projected_crs_geo_key_value(),
+                        Some(2) | Some(3) => geotiff.get_geodetic_crs_geo_key_value(),
+                        _ => None,
+                    };
+                    let vertical = geotiff.get_vertical_crs_geo_key_value();
+                    horizontal.map(|horizontal| Crs::GeoTiffEpsg(horizontal, vertical))
+                } else {
+                    None
+                };
+
                 Ok(ScanResult {
                     bounds,
-                    point_count: hdr.number_of_points(),
+                    point_count: header.number_of_points(),
                     scale_x: t.x.scale,
                     scale_y: t.y.scale,
                     scale_z: t.z.scale,
                     offset_x: t.x.offset,
                     offset_y: t.y.offset,
                     offset_z: t.z.offset,
-                    wkt_crs: hdr
-                        .all_vlrs()
-                        .find(|v| v.is_wkt_crs())
-                        .map(|v| v.data.clone()),
-                    point_format_id: hdr.point_format().to_u8().unwrap_or(0),
+                    crs,
+                    point_format_id: header.point_format().to_u8().unwrap_or(0),
                 })
             })
             .collect();

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,6 +1,6 @@
 /// Validate consistency of scanned input files before building the octree.
 use crate::Error;
-use crate::octree::{ScanResult, input_to_copc_format};
+use crate::octree::{Crs, ScanResult, input_to_copc_format};
 use std::path::PathBuf;
 use tracing::debug;
 
@@ -26,15 +26,64 @@ pub fn validate(
     results: &[ScanResult],
     temporal_index: bool,
 ) -> crate::Result<ValidatedInputs> {
-    let wkt_crs = results[0].wkt_crs.clone();
+    // find a wkt crs
+    let mut wkt_crs = results.iter().enumerate().find_map(|(i, result)| {
+        if let Some(Crs::Wkt(wkt)) = &result.crs {
+            Some((i, Crs::Wkt(wkt.to_owned())))
+        } else {
+            None
+        }
+    });
+    // None of the files have a wkt defined crs
+    if wkt_crs.is_none() {
+        let epsg_crs = results.iter().enumerate().find_map(|(i, r)| {
+            if let Some(Crs::GeoTiffEpsg(horizontal, _vertical)) = r.crs {
+                Some((i, horizontal))
+            } else {
+                None
+            }
+        });
+
+        if let Some((i, epsg)) = epsg_crs {
+            // use the crs-definitions registry to get wkt data
+            debug!("Translating GeoTiffCrs to Wkt, ignoring vertical component.");
+            wkt_crs = crs_definitions::from_code(epsg)
+                .map(|epsg| epsg.wkt.as_bytes().to_vec())
+                .map(Crs::Wkt)
+                .map(|w| (i, w));
+            if wkt_crs.is_none() {
+                debug!("Translating GeoTiffCrs to Wkt failed. Code not found in registry.");
+            }
+        } else {
+            debug!("None of the files contain CRS information.")
+        }
+    }
+
     let first_format = results[0].point_format_id;
 
+    let crs_file_index = if let Some((i, _)) = &wkt_crs { *i } else { 0 };
+    let wkt_crs = wkt_crs.map(|(_, crs)| crs);
+
     for (i, r) in results.iter().enumerate().skip(1) {
-        if r.wkt_crs != wkt_crs {
-            return Err(Error::CrsMismatch {
-                file_a: input_files[0].clone(),
-                file_b: input_files[i].clone(),
-            });
+        match (&wkt_crs, &r.crs) {
+            (None, None) => (),
+            (Some(crs), Some(other)) => {
+                if !crs.is_equal_to(other)? {
+                    debug!("Ignoring vertical CRS-component in CRS comparison");
+                    if !crs.is_equal_to_ignore_vertical_component(other)? {
+                        return Err(Error::CrsMismatch {
+                            file_a: input_files[crs_file_index].clone(),
+                            file_b: input_files[i].clone(),
+                        });
+                    }
+                }
+            }
+            _ => {
+                return Err(Error::CrsMismatch {
+                    file_a: input_files[crs_file_index].clone(),
+                    file_b: input_files[i].clone(),
+                });
+            }
         }
         if r.point_format_id != first_format {
             return Err(Error::PointFormatMismatch {
@@ -45,6 +94,12 @@ pub fn validate(
             });
         }
     }
+
+    let wkt_crs = match wkt_crs {
+        Some(Crs::Wkt(v)) => Some(v),
+        None => None,
+        _ => unreachable!(),
+    };
 
     if temporal_index && !format_has_gps_time(first_format) {
         return Err(Error::NoGpsTime {
@@ -66,7 +121,10 @@ mod tests {
     use super::*;
     use crate::octree::{Bounds, ScanResult};
 
-    fn make_result(wkt: Option<Vec<u8>>, fmt: u8) -> ScanResult {
+    const WGS84_WKT: &[u8; 256] = br#"GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]"#;
+    const EPSG3006_WKT: &[u8; 980] = br#"PROJCRS["SWEREF99 TM",BASEGEOGCRS["SWEREF99",DATUM["SWEREF99",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4619]],CONVERSION["SWEREF99 TM",METHOD["Transverse Mercator",ID["EPSG",9807]],PARAMETER["Latitude of natural origin",0,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",15,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["Scale factor at natural origin",0.9996,SCALEUNIT["unity",1],ID["EPSG",8805]],PARAMETER["False easting",500000,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS[Cartesian,2],AXIS["northing (N)",north,ORDER[1],LENGTHUNIT["metre",1]],AXIS["easting (E)",east,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["Topographic mapping (medium and small scale)."],AREA["Sweden - onshore and offshore."],BBOX[54.96,10.03,69.07,24.17]],ID["EPSG",3006]]"#;
+
+    fn make_result(crs: Option<Crs>, fmt: u8) -> ScanResult {
         ScanResult {
             bounds: Bounds::empty(),
             point_count: 100,
@@ -76,7 +134,7 @@ mod tests {
             offset_x: 0.0,
             offset_y: 0.0,
             offset_z: 0.0,
-            wkt_crs: wkt,
+            crs,
             point_format_id: fmt,
         }
     }
@@ -93,18 +151,51 @@ mod tests {
     #[test]
     fn validate_matching_files() {
         let files = vec![PathBuf::from("a.laz"), PathBuf::from("b.laz")];
-        let wkt = Some(b"WKT".to_vec());
+        let wkt = Some(Crs::Wkt(WGS84_WKT.to_vec()));
         let results = vec![make_result(wkt.clone(), 8), make_result(wkt, 8)];
         let v = validate(&files, &results, false).unwrap();
         assert_eq!(v.point_format, 8);
     }
 
     #[test]
+    fn validate_crs_wkt_and_geotiff() {
+        let files = vec![PathBuf::from("a.laz"), PathBuf::from("b.laz")];
+        let results = vec![
+            make_result(Some(Crs::Wkt(EPSG3006_WKT.to_vec())), 7),
+            make_result(Some(Crs::GeoTiffEpsg(3006, None)), 7),
+        ];
+        let v = validate(&files, &results, false).unwrap();
+        assert_eq!(v.wkt_crs, Some(EPSG3006_WKT.to_vec()));
+    }
+
+    #[test]
+    fn validate_crs_geotiff_and_wkt() {
+        let files = vec![PathBuf::from("a.laz"), PathBuf::from("b.laz")];
+        let results = vec![
+            make_result(Some(Crs::GeoTiffEpsg(3006, None)), 7),
+            make_result(Some(Crs::Wkt(EPSG3006_WKT.to_vec())), 7),
+        ];
+        let v = validate(&files, &results, false).unwrap();
+        assert_eq!(v.wkt_crs, Some(EPSG3006_WKT.to_vec()));
+    }
+
+    #[test]
+    fn validate_crs_geotiff_and_geotiff() {
+        let files = vec![PathBuf::from("a.laz"), PathBuf::from("b.laz")];
+        let results = vec![
+            make_result(Some(Crs::GeoTiffEpsg(3006, None)), 7),
+            make_result(Some(Crs::GeoTiffEpsg(3006, None)), 7),
+        ];
+        let v = validate(&files, &results, false).unwrap();
+        assert_eq!(v.wkt_crs, Some(EPSG3006_WKT.to_vec()));
+    }
+
+    #[test]
     fn validate_crs_mismatch() {
         let files = vec![PathBuf::from("a.laz"), PathBuf::from("b.laz")];
         let results = vec![
-            make_result(Some(b"WKT_A".to_vec()), 7),
-            make_result(Some(b"WKT_B".to_vec()), 7),
+            make_result(Some(Crs::Wkt(WGS84_WKT.to_vec())), 7),
+            make_result(Some(Crs::Wkt(EPSG3006_WKT.to_vec())), 7),
         ];
         let err = validate(&files, &results, false).unwrap_err();
         assert!(matches!(err, Error::CrsMismatch { .. }));


### PR DESCRIPTION
Added support for geotiff crs also.
For only wkt crs'es there should be no changes.
If a there is a mix between wkt and geotiff among the files, the first wkt is taken as the output crs and everything is compared to that.
If only geotiff crses exists in the input files then crs-definitions is used as a registry for getting wkt bytes.