### PR TITLE
Fix Y-coordinate collapse on multi-file inputs with disjoint extents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Multi-file inputs with disjoint extents no longer collapse outlying points
+  onto a single wrong coordinate. The output's scale and offset were taken
+  blindly from the first input file, so points whose true coordinate sat more
+  than `i32::MAX × scale` from that offset would saturate during the
+  `f64 → i32` cast and pile up on the i32 boundary (e.g. ~22 000 m of Y
+  collapsed onto a single Y value). `OctreeBuilder::from_scan` now re-centers
+  the offset on the combined-bounds midpoint when the first file's offset
+  doesn't span the merged extent, and doubles the scale if even the
+  half-extent still won't fit in i32.
+
 ## [0.9.15] - 2026-05-20
 
 ### Fixed

--- a/src/octree.rs
+++ b/src/octree.rs
@@ -721,6 +721,32 @@ impl Bounds {
     }
 }
 
+/// Headroom kept below `i32::MAX` when checking whether
+/// `(world − offset) / scale` is representable. Leaves room for rounding,
+/// the half-scale-unit pad added by [`Bounds::to_cube`], and any tiny
+/// expansion (e.g. an extra point one ULP past the header bounds).
+const I32_HEADROOM: f64 = 2_147_400_000.0;
+
+/// Ensure `min..=max` is representable as `i32 = (world − offset) / scale`.
+///
+/// First re-centers `offset` on the midpoint of `min..max` when the existing
+/// offset would put either endpoint outside the headroom. Then doubles
+/// `scale` until the half-extent fits. Returns `true` iff either value was
+/// changed, so the caller can log the adjustment.
+fn fit_offset_scale(offset: &mut f64, scale: &mut f64, min: f64, max: f64) -> bool {
+    let fits = |o: f64, s: f64| -> bool {
+        ((min - o) / s).abs() <= I32_HEADROOM && ((max - o) / s).abs() <= I32_HEADROOM
+    };
+    let original = (*offset, *scale);
+    if !fits(*offset, *scale) {
+        *offset = 0.5 * (min + max);
+    }
+    while !fits(*offset, *scale) {
+        *scale *= 2.0;
+    }
+    (*offset, *scale) != original
+}
+
 // ---------------------------------------------------------------------------
 // VoxelKey assignment
 // ---------------------------------------------------------------------------
@@ -927,17 +953,20 @@ pub struct OctreeBuilder {
     pub cz: f64,
     /// Half-size of the root voxel.
     pub halfsize: f64,
-    /// X scale factor from the first input file.
+    /// X scale factor. Inherited from the first input file when the combined
+    /// bounds fit in i32 around `offset_x`; otherwise doubled until they do.
     pub scale_x: f64,
-    /// Y scale factor.
+    /// Y scale factor; see [`Self::scale_x`].
     pub scale_y: f64,
-    /// Z scale factor.
+    /// Z scale factor; see [`Self::scale_x`].
     pub scale_z: f64,
-    /// X offset.
+    /// X offset. Inherited from the first input file when its value puts the
+    /// combined min/max within i32 range at `scale_x`; otherwise re-centered
+    /// on the combined-bounds midpoint.
     pub offset_x: f64,
-    /// Y offset.
+    /// Y offset; see [`Self::offset_x`].
     pub offset_y: f64,
-    /// Z offset.
+    /// Z offset; see [`Self::offset_x`].
     pub offset_z: f64,
     /// Temp directory where node files are written.
     pub tmp_dir: PathBuf,
@@ -1085,8 +1114,29 @@ impl OctreeBuilder {
         }
 
         let first = &scan_results[0];
-        let (scale_x, scale_y, scale_z) = (first.scale_x, first.scale_y, first.scale_z);
-        let (offset_x, offset_y, offset_z) = (first.offset_x, first.offset_y, first.offset_z);
+        let (mut scale_x, mut scale_y, mut scale_z) = (first.scale_x, first.scale_y, first.scale_z);
+        let (mut offset_x, mut offset_y, mut offset_z) =
+            (first.offset_x, first.offset_y, first.offset_z);
+
+        // Points are encoded as `i32 = round((world - offset) / scale)`. The
+        // first input's offset/scale are sized for that file's bounds; when
+        // multiple files have disjoint extents, points from outlying files
+        // can fall outside the i32 representable range. Rust's saturating
+        // `f64 as i32` cast then clamps every overflowing point to
+        // `i32::MIN`/`MAX`, collapsing them onto the same wrong coordinate.
+        // Re-center the offset and, if necessary, coarsen the scale so the
+        // combined bounds fit. Scale only ever grows (precision is never
+        // tightened beyond what the first file claimed).
+        let adjusted_x = fit_offset_scale(&mut offset_x, &mut scale_x, bounds.min_x, bounds.max_x);
+        let adjusted_y = fit_offset_scale(&mut offset_y, &mut scale_y, bounds.min_y, bounds.max_y);
+        let adjusted_z = fit_offset_scale(&mut offset_z, &mut scale_z, bounds.min_z, bounds.max_z);
+        if adjusted_x || adjusted_y || adjusted_z {
+            info!(
+                "Adjusted output offset/scale to fit combined extents in i32: \
+                 offset=({offset_x:.6}, {offset_y:.6}, {offset_z:.6}) \
+                 scale=({scale_x:e}, {scale_y:e}, {scale_z:e})",
+            );
+        }
 
         let (cx, cy, cz, halfsize) = bounds.to_cube(scale_x, scale_y, scale_z);
 
@@ -2196,6 +2246,56 @@ impl Drop for OctreeBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fit_offset_scale_keeps_first_file_offset_when_bounds_fit() {
+        // Single-file or homogeneous-extent inputs should be bit-identical
+        // to prior versions: untouched offset and scale.
+        let mut offset = 122_243.6;
+        let mut scale = 0.001;
+        let changed = fit_offset_scale(&mut offset, &mut scale, 122_200.0, 122_287.146);
+        assert!(!changed);
+        assert_eq!(offset, 122_243.6);
+        assert_eq!(scale, 0.001);
+    }
+
+    #[test]
+    fn fit_offset_scale_recenters_when_first_file_offset_is_far() {
+        // Reproduces the disjoint-multi-file Y-clumping bug: the first
+        // file's offset sits at the top of the combined Y range, so the
+        // bottom of the range encodes to ~-4.5e9, well past i32::MIN.
+        // The fix re-centers offset on the combined midpoint; the half
+        // extent then fits comfortably in i32 at the original scale.
+        let mut offset = 455_444.84;
+        let mut scale = 1e-5;
+        let changed = fit_offset_scale(&mut offset, &mut scale, 410_823.89, 455_651.89);
+        assert!(changed);
+        // Re-centered.
+        assert!((offset - 433_237.89).abs() < 0.01, "offset = {offset}");
+        // Scale doubled once: half-extent 22414m / 1e-5 = 2.24e9 > headroom,
+        // so we need 2e-5 (half-extent / 2e-5 = 1.12e9, fits).
+        assert_eq!(scale, 2e-5);
+        // Sanity: both endpoints now fit in i32 with the chosen offset/scale.
+        let lo = ((410_823.89 - offset) / scale).round();
+        let hi = ((455_651.89 - offset) / scale).round();
+        assert!(lo >= i32::MIN as f64 && hi <= i32::MAX as f64);
+    }
+
+    #[test]
+    fn fit_offset_scale_grows_scale_for_extreme_spans() {
+        // Span so wide even a midpoint offset can't fit in i32 at the
+        // input scale; helper should double until it does.
+        let mut offset = 0.0;
+        let mut scale = 1e-5;
+        let half_extent = 100_000.0; // 100km half-span → 200km total
+        let changed = fit_offset_scale(&mut offset, &mut scale, -half_extent, half_extent);
+        assert!(changed);
+        assert_eq!(offset, 0.0); // midpoint
+        assert!(half_extent / scale <= I32_HEADROOM);
+        // Should be a power-of-two multiple of the original scale.
+        let ratio = (scale / 1e-5).round() as u32;
+        assert!(ratio.is_power_of_two(), "scale ratio = {ratio}");
+    }
 
     #[test]
     fn to_cube_pads_halfsize_by_one_scale_unit() {


### PR DESCRIPTION
## Problem

Running the converter on a directory of LAS/LAZ tiles whose individual bounds are disjoint produces an output COPC where many points pile up on a single wrong coordinate. Real example: converting 60 Dutch railway-station tiles spanning ~45 km of Y, every input point with true \`y < 433970 m\` ends up at exactly \`y = 433970.0023 m\` in the output.

The same root cause also triggered false header-bounds-mismatch warnings whose magnitude (~22 km on the Y axis) matched the saturation cliff rather than any real header inaccuracy.

## Root cause

\`OctreeBuilder::from_scan\` was copying \`scale\`/\`offset\` straight from the first scanned file's header. Points are encoded as \`i32 = round((world − offset) / scale)\`; when files further down the input list had bounds far from the first file's offset, that quotient overflowed \`i32\`. Rust's saturating \`f64 as i32\` cast clamped every overflowing value to \`i32::MIN\` (or \`MAX\`), collapsing those points onto a single coordinate.

For the example dataset:
- First file's \`offset_y = 455444.84\` (its own midpoint, sitting at the top of the combined Y range)
- Lowest combined point: \`y = 410823.89\`
- Encoded: \`(410823.89 − 455444.84) / 1e-05 ≈ −4.46 × 10⁹\`, clamped to \`i32::MIN = −2.15 × 10⁹\`
- Decoded back: \`i32::MIN × 1e-05 + 455444.84 = 433970.0023 m\` ← the "wall"

The counting pass round-trips through the same saturating cast to compare against the header bounds, which is why its mismatch report also matched the saturation cliff.

## Fix

New helper \`fit_offset_scale\` runs once per axis after the per-file bounds are merged:
1. Keep the first file's offset and scale when the combined bounds already fit (\`|(min − offset)/scale|\` and \`|(max − offset)/scale|\` both within \`I32_HEADROOM ≈ 2.1474 × 10⁹\`). Single-file and homogeneous-extent inputs remain bit-identical to prior versions, so existing integration fixtures still pass unchanged.
2. Otherwise re-center \`offset\` on the combined-bounds midpoint.
3. If the half-extent still doesn't fit, double \`scale\` until it does. Scale only ever grows; precision is never tightened beyond what the first file claimed.

Three unit tests cover the three branches (keep / recenter / coarsen).

## Verification

On the example dataset (60 LAZ files, 21.5 M points, combined Y span 45 km):

| | min Y | max Y | mean Y | stdev Y |
|---|---|---|---|---|
| Before | **433970.0023** ← cliff | 455651.8879 | 441758.27 | 7955.15 |
| After | 410823.8854 | 455651.8880 | 436462.71 | 14716.93 |

Output now uses \`offset_y = 433237.886\` (recentered midpoint) and \`scale_y = 2e-05\` (auto-bumped once because \`half_extent / 1e-05 = 2.24 × 10⁹ > headroom\`). All 21,528,310 points preserved.

The header-bounds-mismatch warning still fires but now reports honest sub-millimetre per-axis noise from the input file headers themselves rather than the ~22 km saturation artefact.

## Tests

- 3 new unit tests in \`octree::tests\` covering \`fit_offset_scale\`.
- All 21 existing integration tests still pass.
- \`cargo fmt\`, \`cargo clippy --all-targets --features tools\` clean.